### PR TITLE
Use email_late hook

### DIFF
--- a/app/helpers/plugins/camaleon_mandrill/main_helper.rb
+++ b/app/helpers/plugins/camaleon_mandrill/main_helper.rb
@@ -34,7 +34,7 @@ module Plugins::CamaleonMandrill::MainHelper
     arg[:links] << link_to(t('plugin.mandrill.settings.link_name'), admin_plugins_camaleon_mandrill_settings_path)
   end
 
-  def camaleon_mandrill_email(plugin)
+  def camaleon_mandrill_email_late(plugin)
     mandrill_data_config = current_site.get_meta('mandrill_config')
     plugin[:mail_data][:from] = mandrill_data_config[:default_from]
     plugin[:mail_data][:delivery_method] = :smtp

--- a/config/camaleon_plugin.json
+++ b/config/camaleon_plugin.json
@@ -29,8 +29,8 @@
     "plugin_options": [
       "camaleon_mandrill_plugin_options"
     ],
-    "email": [
-      "camaleon_mandrill_email"
+    "email_late": [
+      "camaleon_mandrill_email_late"
     ]
   }
 }


### PR DESCRIPTION
This makes the mandrill plugin work with the latest camaleon-cms version.

Requires https://github.com/owen2345/camaleon-cms/pull/488 to be merged first.
